### PR TITLE
Overwriting the existing cache with the new initialState

### DIFF
--- a/frontend/lib/apollo.ts
+++ b/frontend/lib/apollo.ts
@@ -81,8 +81,8 @@ export const initializeApollo = (
     // Get existing cache, loaded during client side data fetching
     const existingCache = _apolloClient.extract();
 
-    // Merge the existing cache into data passed from getStaticProps/getServerSideProps
-    const data = merge(initialState, existingCache, {
+    // Merge the initialState from getStaticProps/getServerSideProps in the existing cache
+    const data = merge(existingCache, initialState, {
       // combine arrays using object equality (like in sets)
       arrayMerge: (destinationArray, sourceArray) => [
         ...sourceArray,


### PR DESCRIPTION
Been looking at different projects to gather some best practice ideas for implementing apollo and next, and came across your project which I have found very helpful -- thank you.

Assuming it was similarly inspired by the with-apollo example in the NextJS repo, this pull request updates a change that was made and documented here -  https://github.com/vercel/next.js/pull/32733/

Hope it's helpful.